### PR TITLE
Updating dompdf version of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.5.9",
         "iugu/iugu": "1.0.6",
-        "dompdf/dompdf": "^0.6.1"
+        "dompdf/dompdf": "^0.7.0"
     },
     "authors": [
         {

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -2,7 +2,7 @@
 
 namespace Potelo\GuPayment;
 
-use DOMPDF;
+use Dompdf\Dompdf;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\View;
 use Iugu_Invoice;
@@ -102,9 +102,9 @@ class Invoice
             require_once $configPath;
         }
 
-        $dompdf = new DOMPDF;
+        $dompdf = new Dompdf;
 
-        $dompdf->load_html($this->view($data)->render());
+        $dompdf->loadHtml($this->view($data)->render());
 
         $dompdf->render();
 


### PR DESCRIPTION
Com o Laravel 5.3 nao estou conseguindo usar o pacote via composer. Talvez seja porque a versao do dompdf tenha uma incompatiblidade com o phpfonts. Pelo que li em alguns issues do projeto dompdf, isso foi resolvido na versao 0.7.0.
