### PR TITLE
Problema ao cancelar uma assinatura quando ela ainda não foi paga

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -136,7 +136,7 @@ class Subscription extends Model
         if ($this->onTrial()) {
             $this->ends_at = $this->trial_ends_at;
         } else {
-            $this->ends_at = Carbon::createFromFormat('Y-m-d',
+            $this->ends_at = is_null($subscription->expires_at) ? Carbon::now() : Carbon::createFromFormat('Y-m-d',
                 $subscription->expires_at
             );
         }


### PR DESCRIPTION
Quando vai usar o método cancel(), caso a assinatura em questão ainda não tenha a sua última fatura paga, o campo "expires_at" retorna nulo.