### PR TITLE
Ajusta criação de objeto Carbon a partir de `expires_at` no cancelamento da assinatura

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -180,7 +180,7 @@ class Subscription extends Model
         } else {
             $this->ends_at = is_null($subscription->expires_at)
                 ? Carbon::now()
-                : Carbon::createFromFormat('Y-m-d', $subscription->expires_at);
+                : new Carbon($subscription->expires_at);
         }
 
         $this->save();


### PR DESCRIPTION
A API está retornando dois formatos diferentes.

![image](https://user-images.githubusercontent.com/20683045/225079650-41aaaa17-b7ff-469d-b835-8458dee53bd8.png)
